### PR TITLE
feat(no-magic-numbers): ignore array indexes & accept 1000

### DIFF
--- a/index.js
+++ b/index.js
@@ -17,7 +17,7 @@ module.exports = {
         }
     ],
     "rules": {
-        "no-magic-numbers": ["error", { ignore: [0, 1] }],
+        "no-magic-numbers": ["error", { "ignore": [0, 1, 1000], "ignoreArrayIndexes": true }],
         "indent": [
             "error",
             4,


### PR DESCRIPTION
Il y a pas mal d'accès à des éléments de tableaux (ex : data[2]) pour lesquels la règle n'est pas pertinente (on pourrait faire autrement mais ça demande beaucoup de refacto).

Je propose aussi d'accepter 1000 plutôt que d'avoir des constantes du style MILLISECONDS_TO_SECONDS (1000 ça reste explicite)